### PR TITLE
에피그램 5회차 pr

### DIFF
--- a/epigram-main/.env
+++ b/epigram-main/.env
@@ -1,1 +1,1 @@
-NEXT_PUBLIC_API_BASE_URL=https://fe-project-epigram-api.vercel.app/11-시호
+NEXT_PUBLIC_API_BASE_URL=https://fe-project-epigram-api.vercel.app/80-1

--- a/epigram-main/.prettierrc
+++ b/epigram-main/.prettierrc
@@ -1,0 +1,8 @@
+{
+    "printWidth": 100,
+    "tabWidth": 2,
+    "semi": true,
+    "singleQuote": true,
+    "trailingComma": "all",
+    "endOfLine": "auto"
+}

--- a/epigram-main/app/(auth)/login/page.tsx
+++ b/epigram-main/app/(auth)/login/page.tsx
@@ -1,10 +1,10 @@
-"use client";
+'use client';
 
-import React from "react";
-import AuthForm from "@/components/AuthForm";
-import { login } from "@/lib/apis/auth";
-import { useAuthStore } from "@/store/authStore";
-import { useRouter } from "next/navigation";
+import React from 'react';
+import AuthForm from '@/components/AuthForm';
+import { login } from '@/lib/apis/auth';
+import { useAuthStore } from '@/store/authStore';
+import { useRouter } from 'next/navigation';
 
 export default function LoginPage() {
   const setAuth = useAuthStore((state) => state.login);
@@ -12,20 +12,17 @@ export default function LoginPage() {
 
   const handleLogin = async (data: { email: string; password: string }) => {
     try {
-
       const response = await login(data);
 
       const { accessToken, refreshToken, user } = response;
       setAuth(accessToken, refreshToken, user);
 
-      router.push("/");
+      router.push('/');
     } catch (error) {
-      console.error("로그인 실패:", error);
-      alert("로그인에 실패했습니다. 다시 시도해주세요.");
+      console.error('로그인 실패:', error);
+      alert('로그인에 실패했습니다. 다시 시도해주세요.');
     }
   };
 
-  return (
-      <AuthForm type="login" onSubmit={handleLogin} />
-  );
+  return <AuthForm type="login" onSubmit={handleLogin} />;
 }

--- a/epigram-main/app/(auth)/signup/page.tsx
+++ b/epigram-main/app/(auth)/signup/page.tsx
@@ -1,10 +1,10 @@
-"use client";
+'use client';
 
-import React from "react";
-import AuthForm from "@/components/AuthForm";
-import { signUp } from "@/lib/apis/auth";
-import { useRouter } from "next/navigation";
-import { useAuthStore } from "@/store/authStore";
+import React from 'react';
+import AuthForm from '@/components/AuthForm';
+import { signUp } from '@/lib/apis/auth';
+import { useRouter } from 'next/navigation';
+import { useAuthStore } from '@/store/authStore';
 
 export default function SignUpPage() {
   const router = useRouter();
@@ -13,28 +13,38 @@ export default function SignUpPage() {
   const handleSignup = async (data: {
     email: string;
     password: string;
-    passwordConfirmation: string;
-    nickname: string;
+    passwordConfirmation?: string;
+    nickname?: string;
   }) => {
+    if (!data.passwordConfirmation || !data.nickname) {
+      alert('비밀번호 확인 및 닉네임을 입력해주세요.');
+      return;
+    }
+
+    const signUpData = {
+      email: data.email,
+      password: data.password,
+      passwordConfirmation: data.passwordConfirmation,
+      nickname: data.nickname,
+    };
+
     try {
-      const response = await signUp(data);
-      console.log("회원가입 성공:", response);
+      const response = await signUp(signUpData);
+      console.log('회원가입 성공:', response);
 
       const { accessToken, refreshToken, user } = response;
       setAuth(accessToken, refreshToken, user);
 
-      localStorage.setItem("access_token", accessToken);
-      localStorage.setItem("refresh_token", refreshToken);
+      localStorage.setItem('access_token', accessToken);
+      localStorage.setItem('refresh_token', refreshToken);
 
-      alert("회원가입에 성공했습니다!");
-      router.push("/");
+      alert('회원가입에 성공했습니다!');
+      router.push('/');
     } catch (error) {
-      console.error("회원가입 실패:", error);
-      alert("회원가입에 실패했습니다. 다시 시도해주세요.");
+      console.error('회원가입 실패:', error);
+      alert('회원가입에 실패했습니다. 다시 시도해주세요.');
     }
   };
 
-  return (
-      <AuthForm type="signup" onSubmit={handleSignup} />
-  );
+  return <AuthForm type="signup" onSubmit={handleSignup} />;
 }

--- a/epigram-main/app/(epigrams)/addepigram/page.tsx
+++ b/epigram-main/app/(epigrams)/addepigram/page.tsx
@@ -1,28 +1,55 @@
-"use client";
+'use client';
 
-import React, { useState } from "react";
-import styled from "styled-components";
-import { createEpigram } from "@/lib/apis/epigram";
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { createEpigram } from '@/lib/apis/epigram';
+import { useRouter } from 'next/navigation';
+import { useAuthStore } from '@/store/authStore';
 
 export default function AddEpigramPage() {
+  const router = useRouter();
+  const { user } = useAuthStore();
+
   const [formData, setFormData] = useState({
-    tags: "",
-    referenceUrl: "",
-    referenceTitle: "",
-    author: "",
-    content: "",
+    tags: '',
+    referenceUrl: '',
+    referenceTitle: '',
+    author: '',
+    content: '',
   });
-  const [message, setMessage] = useState("");
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState({ content: '', tags: '' });
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { name, value } = e.target;
+
+    if (name === 'content' && value.length > 150) {
+      setError((prev) => ({ ...prev, content: '내용은 최대 150자까지 입력 가능합니다.' }));
+      return;
+    } else {
+      setError((prev) => ({ ...prev, content: '' }));
+    }
+
+    if (name === 'tags') {
+      const tagsArray = value.split(',').map((tag) => tag.trim());
+      if (tagsArray.length > 3) {
+        setError((prev) => ({ ...prev, tags: '태그는 최대 3개까지 입력 가능합니다.' }));
+        return;
+      }
+      if (tagsArray.some((tag) => tag.length > 10)) {
+        setError((prev) => ({ ...prev, tags: '각 태그는 최대 10자까지 입력 가능합니다.' }));
+        return;
+      }
+      setError((prev) => ({ ...prev, tags: '' }));
+    }
+
     setFormData({ ...formData, [name]: value });
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    const tagsArray = formData.tags.split(",").map((tag) => tag.trim());
+    const tagsArray = formData.tags.split(',').map((tag) => tag.trim());
 
     try {
       const response = await createEpigram({
@@ -32,137 +59,142 @@ export default function AddEpigramPage() {
         author: formData.author,
         content: formData.content,
       });
-      console.log("에피그램 추가 성공:", response);
-      setMessage("에피그램이 성공적으로 추가되었습니다!");
+      console.log('에피그램 추가 성공:', response);
+      setMessage('에피그램이 성공적으로 추가되었습니다!');
+      router.push(`/epigrams/${response.id}`);
       setFormData({
-        tags: "",
-        referenceUrl: "",
-        referenceTitle: "",
-        author: "",
-        content: "",
+        tags: '',
+        referenceUrl: '',
+        referenceTitle: '',
+        author: '',
+        content: '',
       });
     } catch (error) {
-      console.error("에피그램 추가 실패:", error);
-      setMessage("에피그램 추가에 실패했습니다. 다시 시도해주세요.");
+      console.error('에피그램 추가 실패:', error);
+      setMessage('에피그램 추가에 실패했습니다. 다시 시도해주세요.');
     }
   };
 
   return (
     <Container>
-        <InnerFormBox>
-      <Form onSubmit={handleSubmit}>
-        <TitleText>에피그램 만들기</TitleText>
-      <Label>내용<span>*</span></Label>
-        <TextArea
-          name="content"
-          value={formData.content}
-          onChange={handleChange}
-          placeholder="200자 이내로 입력해주세요."
-        ></TextArea>
+      <InnerFormBox>
+        <Form onSubmit={handleSubmit}>
+          <TitleText>에피그램 만들기</TitleText>
+          <Label>
+            내용<span>*</span>
+          </Label>
+          <TextArea
+            name="content"
+            value={formData.content}
+            onChange={handleChange}
+            placeholder="150자 이내로 입력해주세요."
+            // maxLength={150}
+          ></TextArea>
+          {error.content && <ErrorMessage>{error.content}</ErrorMessage>}
+          <Label>
+            저자<span>*</span>
+          </Label>
+          <RadioGroup>
+            <RadioOption>
+              <input
+                type="radio"
+                id="direct"
+                name="authorOption"
+                value="직접입력"
+                checked={formData.author === ''}
+                onChange={() => setFormData({ ...formData, author: '' })}
+              />
+              <label htmlFor="direct">직접입력</label>
+            </RadioOption>
+            <RadioOption>
+              <input
+                type="radio"
+                id="unknown"
+                name="authorOption"
+                value="알 수 없음"
+                checked={formData.author === '알 수 없음'}
+                onChange={() => setFormData({ ...formData, author: '알 수 없음' })}
+              />
+              <label htmlFor="unknown">알 수 없음</label>
+            </RadioOption>
+            {user && (
+              <RadioOption>
+                <input
+                  type="radio"
+                  id="self"
+                  name="authorOption"
+                  value="본인"
+                  checked={formData.author === user?.nickname}
+                  onChange={() => setFormData({ ...formData, author: user?.nickname })}
+                />
+                <label htmlFor="self">본인</label>
+              </RadioOption>
+            )}
+          </RadioGroup>
 
-<Label>
-  저자<span>*</span>
-</Label>
-<RadioGroup>
-  <RadioOption>
-    <input
-      type="radio"
-      id="direct"
-      name="authorOption"
-      value="직접입력"
-      checked={formData.author === ""}
-      onChange={() => setFormData({ ...formData, author: "" })}
-    />
-    <label htmlFor="direct">직접입력</label>
-  </RadioOption>
-  <RadioOption>
-    <input
-      type="radio"
-      id="unknown"
-      name="authorOption"
-      value="알 수 없음"
-      checked={formData.author === "알 수 없음"}
-      onChange={() => setFormData({ ...formData, author: "알 수 없음" })}
-    />
-    <label htmlFor="unknown">알 수 없음</label>
-  </RadioOption>
-  <RadioOption>
-    <input
-      type="radio"
-      id="self"
-      name="authorOption"
-      value="본인"
-      checked={formData.author === "본인"}
-      onChange={() => setFormData({ ...formData, author: "본인" })}
-    />
-    <label htmlFor="self">본인</label>
-  </RadioOption>
-</RadioGroup>
+          <Input
+            type="text"
+            name="author"
+            value={formData.author}
+            onChange={handleChange}
+            placeholder="저자 이름 입력"
+          />
 
+          <Label>출처</Label>
+          <Input
+            type="text"
+            name="referenceTitle"
+            value={formData.referenceTitle}
+            onChange={handleChange}
+            placeholder="출처 제목 입력"
+          />
+          <Input
+            type="url"
+            name="referenceUrl"
+            value={formData.referenceUrl}
+            onChange={handleChange}
+            placeholder="URL (ex. https://www.website.com)"
+          />
 
-<Input
-  type="text"
-  name="author"
-  value={formData.author}
-  onChange={handleChange}
-  placeholder="저자 이름 입력"
-/>
+          <Label>태그</Label>
+          <Input
+            type="text"
+            name="tags"
+            value={formData.tags}
+            onChange={handleChange}
+            placeholder="태그 작성 (예: 태그1, 태그2)"
+          />
 
-        <Label>출처</Label>
-        <Input
-          type="text"
-          name="referenceTitle"
-          value={formData.referenceTitle}
-          onChange={handleChange}
-          placeholder="출처 제목 입력"
-        />
-        <Input
-          type="url"
-          name="referenceUrl"
-          value={formData.referenceUrl}
-          onChange={handleChange}
-          placeholder="URL (ex. https://www.website.com)"
-        />
-
-        <Label>태그</Label>
-        <Input
-          type="text"
-          name="tags"
-          value={formData.tags}
-          onChange={handleChange}
-          placeholder="태그 작성 (예: 태그1, 태그2)"
-        />
-
-        <SubmitButton type="submit">작성 완료</SubmitButton>
-        {message && <Message>{message}</Message>}
-      </Form>
+          <SubmitButton type="submit">작성 완료</SubmitButton>
+          {message && <Message>{message}</Message>}
+        </Form>
       </InnerFormBox>
     </Container>
   );
 }
 
 const Container = styled.div`
-    width: 100%;
-    padding: 100px 10px 100px 10px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
+  width: 100%;
+  padding: 100px 10px 100px 10px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
 `;
-const InnerFormBox =styled.div`
+const InnerFormBox = styled.div`
   width: 100%;
   display: flex;
   justify-content: center;
 `;
 
-const TitleText =styled.h2`
-font-family: Pretendard;
-font-size: 22px;
-font-weight: 600;
-line-height: 32px;
-text-align: left;
-text-underline-position: from-font;
-text-decoration-skip-ink: none;
+const TitleText = styled.h2`
+  font-family: Pretendard;
+  font-size: 22px;
+  font-weight: 600;
+  line-height: 32px;
+  text-align: left;
+  text-underline-position: from-font;
+  text-decoration-skip-ink: none;
 `;
 
 const Form = styled.form`
@@ -170,20 +202,20 @@ const Form = styled.form`
   flex-direction: column;
   gap: 16px;
   width: 100%;
-   max-width: 620px;
+  max-width: 620px;
 `;
 
 const Label = styled.label`
-font-family: Pretendard;
-font-size: 16px;
-font-weight: 600;
-line-height: 32px;
-text-align: left;
-text-underline-position: from-font;
-text-decoration-skip-ink: none;
-margin-top: 10px;
-span {
-    color: #FF6577;
+  font-family: Pretendard;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 32px;
+  text-align: left;
+  text-underline-position: from-font;
+  text-decoration-skip-ink: none;
+  margin-top: 10px;
+  span {
+    color: #ff6577;
     margin-left: 6px;
   }
 `;
@@ -191,10 +223,10 @@ span {
 const Input = styled.input`
   padding: 12px;
   font-size: 14px;
-  border: 1px solid #CBD3E1;
+  border: 1px solid #cbd3e1;
   border-radius: 12px;
   &:focus {
-    border-color: #CBD3E1;
+    border-color: #cbd3e1;
     outline: none;
   }
 `;
@@ -202,31 +234,31 @@ const Input = styled.input`
 const TextArea = styled.textarea`
   padding: 8px;
   font-size: 14px;
-  border: 1px solid #CBD3E1;
+  border: 1px solid #cbd3e1;
   border-radius: 12px;
   resize: none;
   height: 160px;
   &:focus {
-    border-color: #CBD3E1;
+    border-color: #cbd3e1;
     outline: none;
   }
 `;
 
 const SubmitButton = styled.button`
   padding: 10px 15px;
-  background-color: #CBD3E1;
+  background-color: #cbd3e1;
   color: #fff;
   font-size: 16px;
   border: none;
   border-radius: 12px;
   cursor: pointer;
-font-family: Pretendard;
-font-size: 16px;
-font-weight: 600;
-line-height: 32px;
-text-align: center;
-text-underline-position: from-font;
-text-decoration-skip-ink: none;
+  font-family: Pretendard;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 32px;
+  text-align: center;
+  text-underline-position: from-font;
+  text-decoration-skip-ink: none;
 
   &:hover {
     background-color: #2d394e;
@@ -238,7 +270,11 @@ const Message = styled.p`
   font-size: 14px;
   color: #2d394e;
 `;
-
+const ErrorMessage = styled.p`
+  font-size: 14px;
+  color: red;
+  margin-top: 4px;
+`;
 
 const RadioGroup = styled.div`
   display: flex;
@@ -251,25 +287,27 @@ const RadioOption = styled.div`
   align-items: center;
   gap: 4px;
 
-  input[type="radio"] {
-    width: 20px; 
-    height: 20px; 
-    accent-color: #40516E;
+  input[type='radio'] {
+    width: 20px;
+    height: 20px;
+    accent-color: #40516e;
     cursor: pointer;
-    transition: background-color 0.3s, border-color 0.3s;
+    transition:
+      background-color 0.3s,
+      border-color 0.3s;
     &:checked {
-        filter: brightness(1.2);
+      filter: brightness(1.2);
     }
   }
 
   label {
     font-family: Pretendard;
-font-size: 16px;
-font-weight: 600;
-line-height: 32px;
-margin-left: 4px;
-text-underline-position: from-font;
-text-decoration-skip-ink: none;
-cursor: pointer;
+    font-size: 16px;
+    font-weight: 600;
+    line-height: 32px;
+    margin-left: 4px;
+    text-underline-position: from-font;
+    text-decoration-skip-ink: none;
+    cursor: pointer;
   }
 `;

--- a/epigram-main/app/(epigrams)/editepigram/[id]/page.tsx
+++ b/epigram-main/app/(epigrams)/editepigram/[id]/page.tsx
@@ -1,10 +1,7 @@
-"use client";
+'use client';
 
-// import EditEpigramPage from "@/components/EditEpigram";
+import EditEpigramPage from '@/components/EditEpigram';
 
-// export default function EditPage({ params }: { params: { id: string } }) {
-//   return <EditEpigramPage params={params} />;
-// }
-export default function EditPage() {
-    return null;
-  }
+export default function EditPage({ params }: { params: Promise<{ id: string }> }) {
+  return <EditEpigramPage params={params} />;
+}

--- a/epigram-main/app/(epigrams)/epigramlist/page.tsx
+++ b/epigram-main/app/(epigrams)/epigramlist/page.tsx
@@ -1,20 +1,56 @@
-"use client";
+'use client';
 
-import React from "react";
-import styled from "styled-components";
-import EpigramListCard from "@/components/EpigramListCard";
-import { useEpigramStore } from "@/store/epigramStore";
-import { useRouter } from "next/navigation";
+import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import EpigramListCard from '@/components/EpigramListCard';
+import { useEpigramStore } from '@/store/epigramStore';
+import { useRouter } from 'next/navigation';
+import { getEpigramList } from '@/lib/apis/epigram';
 
 export default function EpigramListPage() {
-    const router = useRouter();
-  const { epigrams } = useEpigramStore();
+  const router = useRouter();
+  const { epigrams, setEpigrams, addEpigrams } = useEpigramStore();
+  const [cursor, setCursor] = useState<number | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+  // const [hasMore, setHasMore] = useState<boolean>(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setLoading(true);
+      try {
+        const response = await getEpigramList(6);
+        setEpigrams(response.list);
+        setCursor(response.nextCursor ?? null);
+        // setHasMore(response.list.length > 0);
+      } catch (error) {
+        console.error('에피그램 리스트 가져오기 실패:', error);
+      }
+      setLoading(false);
+    };
+
+    fetchData();
+  }, [setEpigrams]);
+
+  const loadMore = async () => {
+    if (!cursor || loading) return;
+
+    setLoading(true);
+    try {
+      const response = await getEpigramList(6, cursor);
+      addEpigrams(response.list);
+      setCursor(response.nextCursor ?? null);
+      // setHasMore(response.list.length > 0);
+    } catch (error) {
+      console.error('추가 데이터 불러오기 실패:', error);
+    }
+    setLoading(false);
+  };
 
   return (
     <Container>
-        <TitleBox>
-            <Title>피드</Title>
-        </TitleBox>
+      <TitleBox>
+        <Title>피드</Title>
+      </TitleBox>
       <GridContainer>
         {epigrams.map((epigram) => (
           <EpigramListCard
@@ -30,10 +66,12 @@ export default function EpigramListPage() {
           />
         ))}
       </GridContainer>
-      <LoadMoreButton>+ 에피그램 더보기</LoadMoreButton>
-      <FloatingButton
-      onClick={() => router.push("/addepigram")}
-      >+ 에피그램 만들기</FloatingButton>
+
+      <LoadMoreButton onClick={loadMore} disabled={loading}>
+        + 에피그램 더보기
+      </LoadMoreButton>
+
+      <FloatingButton onClick={() => router.push('/addepigram')}>+ 에피그램 만들기</FloatingButton>
     </Container>
   );
 }
@@ -47,23 +85,21 @@ const Container = styled.div`
 `;
 
 const TitleBox = styled.div`
-    width: 100%;
-    margin-top: 30px;
-    margin-bottom: 20px;
-    max-width: 1200px;
+  width: 100%;
+  margin-top: 30px;
+  margin-bottom: 20px;
+  max-width: 1200px;
 `;
 
 const Title = styled.h1`
-font-family: Pretendard;
-font-size: 24px;
-font-weight: 600;
-line-height: 32px;
-text-align: left;
-text-underline-position: from-font;
-text-decoration-skip-ink: none;
+  font-family: Pretendard;
+  font-size: 24px;
+  font-weight: 600;
+  line-height: 32px;
+  text-align: left;
+  text-underline-position: from-font;
+  text-decoration-skip-ink: none;
 `;
-
-
 
 const GridContainer = styled.div`
   display: grid;
@@ -72,11 +108,10 @@ const GridContainer = styled.div`
   width: 100%;
   max-width: 1200px;
 
-  @media (max-width: 1200px) { 
-    grid-template-columns: 1fr; 
+  @media (max-width: 1200px) {
+    grid-template-columns: 1fr;
   }
 `;
-
 
 const LoadMoreButton = styled.button`
   margin-top: 20px;
@@ -85,15 +120,15 @@ const LoadMoreButton = styled.button`
   border-radius: 30px;
   cursor: pointer;
   font-size: 16px;
-  color:#8B9DBC;
+  color: #8b9dbc;
   transition: background-color 0.3s;
-font-family: Pretendard;
-font-size: 20px;
-font-weight: 500;
-line-height: 32px;
-text-align: left;
-text-underline-position: from-font;
-text-decoration-skip-ink: none;
+  font-family: Pretendard;
+  font-size: 20px;
+  font-weight: 500;
+  line-height: 32px;
+  text-align: left;
+  text-underline-position: from-font;
+  text-decoration-skip-ink: none;
 
   &:hover {
     background-color: #e0e0e0;
@@ -106,17 +141,17 @@ const FloatingButton = styled.button`
   right: 50px;
   width: 180px;
   height: 60px;
-  background-color: #2D394E;
+  background-color: #2d394e;
   color: white;
   border: none;
   border-radius: 30px;
-font-family: Pretendard;
-font-size: 18px;
-font-weight: 600;
-line-height: 32px;
-text-align: center;
-text-underline-position: from-font;
-text-decoration-skip-ink: none;
+  font-family: Pretendard;
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 32px;
+  text-align: center;
+  text-underline-position: from-font;
+  text-decoration-skip-ink: none;
 
   cursor: pointer;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);

--- a/epigram-main/app/(epigrams)/epigrams/[id]/page.tsx
+++ b/epigram-main/app/(epigrams)/epigrams/[id]/page.tsx
@@ -1,113 +1,65 @@
-"use client";
+'use client';
 
-import React from "react";
-import styled from "styled-components";
-import EpigramDetailInfo from "@/components/EpigramDetailInfo";
-import {use} from 'react';
+import React, { useEffect, useState, use } from 'react';
+import styled from 'styled-components';
+import { useEpigramStore } from '@/store/epigramStore';
+import { useCommentStore } from '@/store/commentStore';
+import { getEpigramDetail } from '@/lib/apis/epigram';
+import EpigramDetailInfo from '@/components/EpigramDetailInfo';
+import EpigramComment from '@/components/EpigramComment';
 
-export default function EpigramDetailPage({
-  params,
-}: {
-  params: Promise<{ id: string }>;
-}) {
+export default function EpigramDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { epigramDetail, setEpigramDetail } = useEpigramStore();
+  const [loading, setLoading] = useState<boolean>(true);
+  const { comments, fetchComments } = useCommentStore();
+  const { id } = use(params);
 
-    const dummyEpigrams = [
-        {
-          id: 1,
-          likeCount: 12,
-          tags: [{ name: "인생", id: 201 }, { name: "성장", id: 202 }],
-          writerId: 301,
-          referenceUrl: "https://naver.com",
-          referenceTitle: "삶의 지혜",
-          author: "작가 1",
-          content: "삶은 매일 새로운 기회를 제공하지만, 이를 알아보는 것은 우리의 몫이다. 주어진 시간에 최선을 다하라.",
-          isLiked: false,
-        },
-        {
-          id: 2,
-          likeCount: 8,
-          tags: [{ name: "지혜", id: 203 }, { name: "철학", id: 204 }],
-          writerId: 302,
-          referenceUrl: "https://naver.com",
-          referenceTitle: "지혜로운 삶",
-          author: "작가 2",
-          content: "지혜는 경험에서 나오는 것이 아니라, 경험을 어떻게 활용하느냐에 따라 결정된다.",
-          isLiked: true,
-        },
-        {
-          id: 3,
-          likeCount: 20,
-          tags: [{ name: "도전", id: 205 }, { name: "희망", id: 206 }],
-          writerId: 303,
-          referenceUrl: "https://naver.com",
-          referenceTitle: "희망의 등불",
-          author: "작가 3",
-          content: "어두운 밤이 길수록 새벽은 더욱 찬란하다. 어려움 속에서도 희망을 잃지 마라.",
-          isLiked: false,
-        },
-        {
-          id: 4,
-          likeCount: 15,
-          tags: [{ name: "사랑", id: 207 }, { name: "공감", id: 208 }],
-          writerId: 304,
-          referenceUrl: "https://naver.com",
-          referenceTitle: "사랑의 정의",
-          author: "작가 4",
-          content: "사랑은 서로 다른 두 마음이 하나로 연결되는 순간에 서로가 사랑하게 된다",
-          isLiked: true,
-        },
-        {
-          id: 5,
-          likeCount: 25,
-          tags: [{ name: "책", id: 209 }, { name: "독서", id: 210 }],
-          writerId: 305,
-          referenceUrl: "https://naver.com",
-          referenceTitle: "독서의 즐거움",
-          author: "작가 5",
-          content: "책을 읽는다는 것은 새로운 세상으로 떠나는 여행과 같다. 독서는 우리의 영혼을 풍요롭게 한다.",
-          isLiked: false,
-        },
-        {
-          id: 6,
-          likeCount: 18,
-          tags: [
-            { name: "자기계발", id: 211 },
-            { name: "목표", id: 212 },
-            { name: "성취", id: 213 },
-          ],
-          writerId: 306,
-          referenceUrl: "https://naver.com",
-          referenceTitle: "목표를 이루는 법",
-          author: "작가 6",
-          content: "작은 목표를 이루는 것이 큰 목표를 달성하는 첫걸음이다. 꾸준히 걸어가는 것이 중요하다.",
-          isLiked: true,
-        },
-      ];
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        const response = await getEpigramDetail(parseInt(id, 10));
+        setEpigramDetail(response);
+        await fetchComments(parseInt(id, 10), 10);
+      } catch (error) {
+        console.error('에피그램 상세 정보를 불러오지 못했습니다:', error);
+      }
+      setLoading(false);
+    };
 
+    fetchData();
+  }, [id, setEpigramDetail, fetchComments]);
 
-      const { id } = use(params);
-
-      const epigramDetail = dummyEpigrams.find(
-        (epigram) => epigram.id === parseInt(id, 10)
-      );
+  if (loading) {
+    return <p>로딩 중...</p>;
+  }
 
   if (!epigramDetail) {
-    return <p>해당 에피그램을 찾을 수 없습니다.</p>;
+    return (
+      <Container>
+        <NoListText>해당 에피그램을 찾을 수 없습니다.</NoListText>;
+      </Container>
+    );
   }
 
   return (
     <Container>
       <EpigramDetailInfo epigram={epigramDetail} />
-      {/* 댓글창 컴포넌트 자리 */}
+      <EpigramComment comments={comments} epigramId={parseInt(id, 10)} />
     </Container>
   );
 }
 
-
 const Container = styled.div`
- display: flex;
-flex-direction: column;
-justify-content: center;
-align-items: center;
-width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+`;
+
+const NoListText = styled.h3`
+  text-align: center;
+  font-size: 24px;
+  color: red;
 `;

--- a/epigram-main/components/AuthForm.tsx
+++ b/epigram-main/components/AuthForm.tsx
@@ -1,9 +1,9 @@
-"use client";
+'use client';
 
-import React, { useState } from "react";
-import styled from "styled-components";
-import Image from "next/image";
-import { useRouter } from "next/navigation";
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 
 const Container = styled.div`
   display: flex;
@@ -14,67 +14,62 @@ const Container = styled.div`
   padding: 100px 10px 100px 10px;
 `;
 
-const InnerFormBox =styled.div`
+const InnerFormBox = styled.div`
   width: 620px;
-`
+`;
+
 const Form = styled.form`
   width: 100%;
 `;
 
 const Header = styled.div`
-display: flex;
-justify-content: center;
-margin-bottom: 34px;
+  display: flex;
+  justify-content: center;
+  margin-bottom: 34px;
 `;
 
-
-const Input = styled.input`
+const Input = styled.input<{ error?: boolean }>`
   width: 100%;
   padding: 12px;
-  border: 1px solid #ECEFF4;
+  border: 1px solid ${({ error }) => (error ? '#e74c3c' : '#ECEFF4')};
   border-radius: 6px;
   font-size: 14px;
-  margin-bottom: 16px;
+  margin-bottom: 8px;
   background: #f7f9fc;
   &:focus {
-    border-color: #CBD3E1;
+    border-color: #cbd3e1;
     outline: none;
   }
 `;
 
 const Label = styled.p`
-font-family: Pretendard;
-font-size: 18px;
-font-weight: 500;
-line-height: 22px;
-text-align: left;
-text-underline-position: from-font;
-text-decoration-skip-ink: none;
-color:#2D394E;
-margin: 20px 0 12px 10px;
-width: 100%;
+  font-family: Pretendard;
+  font-size: 18px;
+  font-weight: 500;
+  text-align: left;
+  color: #2d394e;
+  margin: 20px 0 12px 10px;
 `;
 
 const ErrorMessage = styled.p`
   color: #e74c3c;
   font-size: 14px;
-  margin-bottom: 16px;
+  margin-bottom: 8px;
 `;
 
 const SubmitButton = styled.button`
   width: 100%;
   padding: 12px;
-  background-color: #CBD3E1;
+  background-color: #cbd3e1;
   color: #fff;
   font-size: 16px;
   border: none;
   border-radius: 6px;
   cursor: pointer;
-
   &:hover {
-    background-color: #2D394E;
+    background-color: #2d394e;
   }
-  `;
+`;
 
 const NaviContainer = styled.div`
   margin-top: 16px;
@@ -86,9 +81,8 @@ const NaviText = styled.p`
   font-family: Pretendard;
   font-size: 14px;
   font-weight: 500;
-  color: #ABB8CE;
+  color: #abb8ce;
   margin-bottom: 4px;
-
   &:last-child {
     color: #454545;
     cursor: pointer;
@@ -101,116 +95,159 @@ const NaviText = styled.p`
 `;
 
 interface AuthFormProps {
-  type: "login" | "signup";
+  type: 'login' | 'signup';
   onSubmit: (data: {
     email: string;
     password: string;
-    passwordConfirmation: string;
-    nickname: string;
+    passwordConfirmation?: string;
+    nickname?: string;
   }) => void;
 }
 
 export default function AuthForm({ type, onSubmit }: AuthFormProps) {
   const router = useRouter();
 
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [confirmPassword, setConfirmPassword] = useState("");
-  const [nickname, setNickname] = useState("");
-  const [error, setError] = useState("");
+  // ✅ 상태 관리
+  const [formData, setFormData] = useState({
+    email: '',
+    password: '',
+    confirmPassword: '',
+    nickname: '',
+  });
+  const [errors, setErrors] = useState({
+    email: '',
+    password: '',
+    confirmPassword: '',
+    nickname: '',
+  });
+  const [globalError, setGlobalError] = useState('');
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (
-      !email ||
-      !password ||
-      (type === "signup" &&
-        (!nickname || !confirmPassword || password !== confirmPassword))
-    ) {
-      setError("모든 필드를 올바르게 입력해주세요.");
-      return;
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value });
+    setErrors({ ...errors, [e.target.name]: '' });
+    setGlobalError('');
+  };
+
+  const validateForm = () => {
+    let isValid = true;
+    const newErrors = { email: '', password: '', confirmPassword: '', nickname: '' };
+
+    if (!formData.email) {
+      newErrors.email = '이메일은 필수 입력입니다.';
+      isValid = false;
+    } else if (!/^\S+@\S+\.\S+$/.test(formData.email)) {
+      newErrors.email = '이메일 형식으로 작성해 주세요.';
+      isValid = false;
     }
 
-    setError("");
-    onSubmit({
-      email,
-      password,
-      ...(type === "signup" && {
-        passwordConfirmation: confirmPassword,
-        nickname,
-      }),
-    } as {
-      email: string;
-      password: string;
-      passwordConfirmation: string;
-      nickname: string;
-    });
+    if (!formData.password) {
+      newErrors.password = '비밀번호는 필수 입력입니다.';
+      isValid = false;
+    }
+
+    if (type === 'signup') {
+      if (!formData.confirmPassword) {
+        newErrors.confirmPassword = '비밀번호 확인은 필수 입력입니다.';
+        isValid = false;
+      } else if (formData.password !== formData.confirmPassword) {
+        newErrors.confirmPassword = '비밀번호가 일치하지 않습니다.';
+        isValid = false;
+      }
+
+      if (!formData.nickname) {
+        newErrors.nickname = '닉네임은 필수 입력입니다.';
+        isValid = false;
+      }
+    }
+
+    setErrors(newErrors);
+    return isValid;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!validateForm()) return;
+
+    try {
+      await onSubmit({
+        email: formData.email,
+        password: formData.password,
+        ...(type === 'signup' && {
+          passwordConfirmation: formData.confirmPassword,
+          nickname: formData.nickname,
+        }),
+      });
+    } catch (error: any) {
+      if (error.response?.status === 500 && type === 'signup') {
+        setErrors((prev) => ({ ...prev, nickname: '이미 사용 중인 닉네임입니다.' }));
+      } else {
+        setGlobalError('아이디 또는 비밀번호가 일치하지 않습니다.');
+      }
+    }
   };
 
   return (
     <Container>
-        <InnerFormBox>
-      <Form onSubmit={handleSubmit}>
-        <Header>
-          <Image
-          src="/images/login_log.png"
-          alt="로그인 로고"
-          width={172}
-          height={48}
-          priority
-        />
-        </Header>
-        {
-            type === "signup"? <Label>이메일</Label>:null
-        }
-        <Input
-          type="email"
-          placeholder="이메일"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-        />
-        {
-            type === "signup"? <Label>비밀번호</Label>:null
-        }
-        <Input
-          type="password"
-          placeholder="비밀번호"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-        />
+      <InnerFormBox>
+        <Form onSubmit={handleSubmit}>
+          <Header>
+            <Image src="/images/login_log.png" alt="로그인 로고" width={172} height={48} priority />
+          </Header>
 
-        {type === "signup" && (
-          <>
-            <Input
-              type="password"
-              placeholder="비밀번호 확인"
-              value={confirmPassword}
-              onChange={(e) => setConfirmPassword(e.target.value)}
-            />
-            <Label>닉네임</Label>
-            <Input
-              type="text"
-              placeholder="닉네임"
-              value={nickname}
-              onChange={(e) => setNickname(e.target.value)}
-            />
-          </>
-        )}
+          <Label>이메일</Label>
+          <Input
+            type="email"
+            name="email"
+            placeholder="이메일"
+            value={formData.email}
+            onChange={handleChange}
+          />
+          {errors.email && <ErrorMessage>{errors.email}</ErrorMessage>}
 
-        {error && <ErrorMessage>{error}</ErrorMessage>}
+          <Label>비밀번호</Label>
+          <Input
+            type="password"
+            name="password"
+            placeholder="비밀번호"
+            value={formData.password}
+            onChange={handleChange}
+          />
+          {errors.password && <ErrorMessage>{errors.password}</ErrorMessage>}
 
-        <SubmitButton type="submit">
-          {type === "login" ? "로그인" : "가입하기"}
-        </SubmitButton>
-        {
-            type === "login"? 
+          {type === 'signup' && (
+            <>
+              <Label>비밀번호 확인</Label>
+              <Input
+                type="password"
+                name="confirmPassword"
+                placeholder="비밀번호 확인"
+                value={formData.confirmPassword}
+                onChange={handleChange}
+              />
+              {errors.confirmPassword && <ErrorMessage>{errors.confirmPassword}</ErrorMessage>}
+
+              <Label>닉네임</Label>
+              <Input
+                type="text"
+                name="nickname"
+                placeholder="닉네임"
+                value={formData.nickname}
+                onChange={handleChange}
+              />
+              {errors.nickname && <ErrorMessage>{errors.nickname}</ErrorMessage>}
+            </>
+          )}
+
+          {globalError && <ErrorMessage>{globalError}</ErrorMessage>}
+
+          <SubmitButton type="submit">{type === 'login' ? '로그인' : '가입하기'}</SubmitButton>
+          {type === 'login' ? (
             <NaviContainer>
-            <NaviText>회원이 아니신가요?</NaviText>
-            <NaviText onClick={() => router.push("/signup")}>가입하기</NaviText>
+              <NaviText>회원이 아니신가요?</NaviText>
+              <NaviText onClick={() => router.push('/signup')}>가입하기</NaviText>
             </NaviContainer>
-            :null
-        }
-      </Form>
+          ) : null}
+        </Form>
       </InnerFormBox>
     </Container>
   );

--- a/epigram-main/components/CommentInput.tsx
+++ b/epigram-main/components/CommentInput.tsx
@@ -1,0 +1,115 @@
+// components/CommentInput.tsx
+'use client';
+
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { useCommentStore } from '@/store/commentStore';
+import { createEpigramComment } from '@/lib/apis/comment';
+import { useAuthStore } from '@/store/authStore';
+import Image from 'next/image';
+
+interface CommentInputProps {
+  epigramId: number;
+}
+
+export default function CommentInput({ epigramId }: CommentInputProps) {
+  const { user } = useAuthStore();
+  const [comment, setComment] = useState('');
+  //   const [isPrivate, setIsPrivate] = useState(false);
+  const isPrivate = false;
+  const { fetchComments } = useCommentStore();
+
+  console.log('user123', user);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!comment.trim()) return;
+
+    try {
+      await createEpigramComment({ epigramId, content: comment, isPrivate });
+      setComment('');
+      fetchComments(epigramId, 10);
+    } catch (error) {
+      console.error('댓글 등록 실패:', error);
+    }
+  };
+
+  return (
+    <FormContainer onSubmit={handleSubmit}>
+      <FormHeaderContainer>
+        {user?.image ? (
+          <ProfileImgContainer>
+            <Image src={user?.image} alt="유저" width={30} height={30} />
+          </ProfileImgContainer>
+        ) : (
+          <ProfileImgContainer>
+            <Image src="/images/user.png" alt="유저" width={30} height={30} />
+          </ProfileImgContainer>
+        )}
+        <Textarea
+          value={comment}
+          onChange={(e) => setComment(e.target.value)}
+          placeholder="댓글을 입력하세요..."
+        />
+      </FormHeaderContainer>
+      <BtnContainer>
+        <SubmitButton type="submit">등록</SubmitButton>
+      </BtnContainer>
+    </FormContainer>
+  );
+}
+
+const FormContainer = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+  max-width: 640px;
+  margin-bottom: 20px;
+`;
+
+const FormHeaderContainer = styled.div`
+  display: flex;
+`;
+const ProfileImgContainer = styled.div`
+  margin-right: 30px;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 50%;
+  overflow: hidden;
+`;
+
+const Textarea = styled.textarea`
+  width: 100%;
+  height: 80px;
+  padding: 10px;
+  border: 1px solid #ddd;
+  border-radius: 10px;
+  font-size: 14px;
+  resize: none;
+  &:focus {
+    border-color: #cbd3e1;
+    outline: none;
+  }
+`;
+
+const BtnContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+`;
+
+const SubmitButton = styled.button`
+  width: 120px;
+  background-color: #2d394e;
+  color: white;
+  padding: 8px 12px;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  &:hover {
+    background-color: #242e3f;
+  }
+`;

--- a/epigram-main/components/EditEpigram.tsx
+++ b/epigram-main/components/EditEpigram.tsx
@@ -1,291 +1,296 @@
-// "use client";
+'use client';
 
-// import React, { useEffect, useState } from "react";
-// import styled from "styled-components";
-// import { updateEpigram, getEpigramDetail } from "@/lib/apis/epigram";
-// import { useRouter } from "next/navigation";
+import React, { useEffect, useState, use } from 'react';
+import styled from 'styled-components';
+import { updateEpigram, getEpigramDetail } from '@/lib/apis/epigram';
+import { useRouter } from 'next/navigation';
 
-// export default function EditEpigramPage({ params }: { params: { id: string } }) {
-//   const router = useRouter();
-//   const epigramId = parseInt(params.id, 10);
+export default function EditEpigramPage({ params }: { params: Promise<{ id: string }> }) {
+  const router = useRouter();
+  const { id } = use(params);
+  const epigramId = parseInt(id, 10);
 
-//   const [formData, setFormData] = useState({
-//     tags: "",
-//     referenceUrl: "",
-//     referenceTitle: "",
-//     author: "",
-//     content: "",
-//   });
-//   const [message, setMessage] = useState("");
+  const [formData, setFormData] = useState({
+    tags: '',
+    referenceUrl: '',
+    referenceTitle: '',
+    author: '',
+    content: '',
+  });
+  const [message, setMessage] = useState('');
 
-//   useEffect(() => {
-//     const fetchEpigram = async () => {
-//       try {
-//         const response = await getEpigramDetail(epigramId);
-//         const tagsString = response.tags.map((tag: any) => tag.name).join(", ");
-//         setFormData({
-//           tags: tagsString,
-//           referenceUrl: response.referenceUrl,
-//           referenceTitle: response.referenceTitle,
-//           author: response.author,
-//           content: response.content,
-//         });
-//       } catch (error) {
-//         console.error("에피그램 데이터를 불러오지 못했습니다:", error);
-//       }
-//     };
+  useEffect(() => {
+    const fetchEpigram = async () => {
+      try {
+        const response = await getEpigramDetail(epigramId);
+        const tagsString = response.tags.map((tag: any) => tag.name).join(', ');
+        setFormData({
+          tags: tagsString,
+          referenceUrl: response.referenceUrl,
+          referenceTitle: response.referenceTitle,
+          author: response.author,
+          content: response.content,
+        });
+      } catch (error) {
+        console.error('에피그램 데이터를 불러오지 못했습니다:', error);
+      }
+    };
 
-//     fetchEpigram();
-//   }, [epigramId]);
+    fetchEpigram();
+  }, [epigramId]);
 
-//   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-//     const { name, value } = e.target;
-//     setFormData({ ...formData, [name]: value });
-//   };
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = e.target;
+    setFormData({ ...formData, [name]: value });
+  };
 
-//   const handleSubmit = async (e: React.FormEvent) => {
-//     e.preventDefault();
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
 
-//     const tagsArray = formData.tags.split(",").map((tag) => tag.trim());
+    const tagsArray = formData.tags.split(',').map((tag) => tag.trim());
 
-//     try {
-//       const response = await updateEpigram(epigramId, {
-//         tags: tagsArray,
-//         referenceUrl: formData.referenceUrl,
-//         referenceTitle: formData.referenceTitle,
-//         author: formData.author,
-//         content: formData.content,
-//       });
-//       console.log("수정 성공:", response);
-//       setMessage("에피그램이 성공적으로 수정되었습니다!");
-//       router.push("/epigramlist");
-//     } catch (error) {
-//       console.error("수정 실패:", error);
-//       setMessage("에피그램 수정에 실패했습니다. 다시 시도해주세요.");
-//     }
-//   };
+    try {
+      const response = await updateEpigram(epigramId, {
+        tags: tagsArray,
+        referenceUrl: formData.referenceUrl,
+        referenceTitle: formData.referenceTitle,
+        author: formData.author,
+        content: formData.content,
+      });
+      console.log('수정 성공:', response);
+      setMessage('에피그램이 성공적으로 수정되었습니다!');
+      router.push('/epigramlist');
+    } catch (error) {
+      console.error('수정 실패:', error);
+      setMessage('에피그램 수정에 실패했습니다. 다시 시도해주세요.');
+    }
+  };
 
-//   return (
-//     <Container>
-//       <InnerFormBox>
-//         <Form onSubmit={handleSubmit}>
-//           <TitleText>에피그램 수정하기</TitleText>
-//           <Label>내용<span>*</span></Label>
-//           <TextArea
-//             name="content"
-//             value={formData.content}
-//             onChange={handleChange}
-//             placeholder="200자 이내로 입력해주세요."
-//           ></TextArea>
+  return (
+    <Container>
+      <InnerFormBox>
+        <Form onSubmit={handleSubmit}>
+          <TitleText>에피그램 수정하기</TitleText>
+          <Label>
+            내용<span>*</span>
+          </Label>
+          <TextArea
+            name="content"
+            value={formData.content}
+            onChange={handleChange}
+            placeholder="200자 이내로 입력해주세요."
+          ></TextArea>
 
-//           <Label>저자<span>*</span></Label>
-//           <RadioGroup>
-//             <RadioOption>
-//               <input
-//                 type="radio"
-//                 id="direct"
-//                 name="authorOption"
-//                 value="직접입력"
-//                 checked={formData.author === ""}
-//                 onChange={() => setFormData({ ...formData, author: "" })}
-//               />
-//               <label htmlFor="direct">직접입력</label>
-//             </RadioOption>
-//             <RadioOption>
-//               <input
-//                 type="radio"
-//                 id="unknown"
-//                 name="authorOption"
-//                 value="알 수 없음"
-//                 checked={formData.author === "알 수 없음"}
-//                 onChange={() => setFormData({ ...formData, author: "알 수 없음" })}
-//               />
-//               <label htmlFor="unknown">알 수 없음</label>
-//             </RadioOption>
-//             <RadioOption>
-//               <input
-//                 type="radio"
-//                 id="self"
-//                 name="authorOption"
-//                 value="본인"
-//                 checked={formData.author === "본인"}
-//                 onChange={() => setFormData({ ...formData, author: "본인" })}
-//               />
-//               <label htmlFor="self">본인</label>
-//             </RadioOption>
-//           </RadioGroup>
+          <Label>
+            저자<span>*</span>
+          </Label>
+          <RadioGroup>
+            <RadioOption>
+              <input
+                type="radio"
+                id="direct"
+                name="authorOption"
+                value="직접입력"
+                checked={formData.author === ''}
+                onChange={() => setFormData({ ...formData, author: '' })}
+              />
+              <label htmlFor="direct">직접입력</label>
+            </RadioOption>
+            <RadioOption>
+              <input
+                type="radio"
+                id="unknown"
+                name="authorOption"
+                value="알 수 없음"
+                checked={formData.author === '알 수 없음'}
+                onChange={() => setFormData({ ...formData, author: '알 수 없음' })}
+              />
+              <label htmlFor="unknown">알 수 없음</label>
+            </RadioOption>
+            <RadioOption>
+              <input
+                type="radio"
+                id="self"
+                name="authorOption"
+                value="본인"
+                checked={formData.author === '본인'}
+                onChange={() => setFormData({ ...formData, author: '본인' })}
+              />
+              <label htmlFor="self">본인</label>
+            </RadioOption>
+          </RadioGroup>
 
-//           <Input
-//             type="text"
-//             name="author"
-//             value={formData.author}
-//             onChange={handleChange}
-//             placeholder="저자 이름 입력"
-//           />
+          <Input
+            type="text"
+            name="author"
+            value={formData.author}
+            onChange={handleChange}
+            placeholder="저자 이름 입력"
+          />
 
-//           <Label>출처</Label>
-//           <Input
-//             type="text"
-//             name="referenceTitle"
-//             value={formData.referenceTitle}
-//             onChange={handleChange}
-//             placeholder="출처 제목 입력"
-//           />
-//           <Input
-//             type="url"
-//             name="referenceUrl"
-//             value={formData.referenceUrl}
-//             onChange={handleChange}
-//             placeholder="URL (ex. https://www.website.com)"
-//           />
+          <Label>출처</Label>
+          <Input
+            type="text"
+            name="referenceTitle"
+            value={formData.referenceTitle}
+            onChange={handleChange}
+            placeholder="출처 제목 입력"
+          />
+          <Input
+            type="url"
+            name="referenceUrl"
+            value={formData.referenceUrl}
+            onChange={handleChange}
+            placeholder="URL (ex. https://www.website.com)"
+          />
 
-//           <Label>태그</Label>
-//           <Input
-//             type="text"
-//             name="tags"
-//             value={formData.tags}
-//             onChange={handleChange}
-//             placeholder="태그 작성 (예: 태그1, 태그2)"
-//           />
+          <Label>태그</Label>
+          <Input
+            type="text"
+            name="tags"
+            value={formData.tags}
+            onChange={handleChange}
+            placeholder="태그 작성 (예: 태그1, 태그2)"
+          />
 
-//           <SubmitButton type="submit">수정 완료</SubmitButton>
-//           {message && <Message>{message}</Message>}
-//         </Form>
-//       </InnerFormBox>
-//     </Container>
-//   );
-// }
+          <SubmitButton type="submit">수정 완료</SubmitButton>
+          {message && <Message>{message}</Message>}
+        </Form>
+      </InnerFormBox>
+    </Container>
+  );
+}
 
+const Container = styled.div`
+  width: 100%;
+  padding: 100px 10px 100px 10px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+`;
+const InnerFormBox = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+`;
 
-// const Container = styled.div`
-//     width: 100%;
-//     padding: 100px 10px 100px 10px;
-//     display: flex;
-//     flex-direction: column;
-//     align-items: center;
-//     justify-content: center;
-// `;
-// const InnerFormBox =styled.div`
-//   width: 100%;
-//   display: flex;
-//   justify-content: center;
-// `;
+const TitleText = styled.h2`
+  font-family: Pretendard;
+  font-size: 22px;
+  font-weight: 600;
+  line-height: 32px;
+  text-align: left;
+  text-underline-position: from-font;
+  text-decoration-skip-ink: none;
+`;
 
-// const TitleText =styled.h2`
-// font-family: Pretendard;
-// font-size: 22px;
-// font-weight: 600;
-// line-height: 32px;
-// text-align: left;
-// text-underline-position: from-font;
-// text-decoration-skip-ink: none;
-// `;
+const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  width: 100%;
+  max-width: 620px;
+`;
 
-// const Form = styled.form`
-//   display: flex;
-//   flex-direction: column;
-//   gap: 16px;
-//   width: 100%;
-//    max-width: 620px;
-// `;
+const Label = styled.label`
+  font-family: Pretendard;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 32px;
+  text-align: left;
+  text-underline-position: from-font;
+  text-decoration-skip-ink: none;
+  margin-top: 10px;
+  span {
+    color: #ff6577;
+    margin-left: 6px;
+  }
+`;
 
-// const Label = styled.label`
-// font-family: Pretendard;
-// font-size: 16px;
-// font-weight: 600;
-// line-height: 32px;
-// text-align: left;
-// text-underline-position: from-font;
-// text-decoration-skip-ink: none;
-// margin-top: 10px;
-// span {
-//     color: #FF6577;
-//     margin-left: 6px;
-//   }
-// `;
+const Input = styled.input`
+  padding: 12px;
+  font-size: 14px;
+  border: 1px solid #cbd3e1;
+  border-radius: 12px;
+  &:focus {
+    border-color: #cbd3e1;
+    outline: none;
+  }
+`;
 
-// const Input = styled.input`
-//   padding: 12px;
-//   font-size: 14px;
-//   border: 1px solid #CBD3E1;
-//   border-radius: 12px;
-//   &:focus {
-//     border-color: #CBD3E1;
-//     outline: none;
-//   }
-// `;
+const TextArea = styled.textarea`
+  padding: 8px;
+  font-size: 14px;
+  border: 1px solid #cbd3e1;
+  border-radius: 12px;
+  resize: none;
+  height: 160px;
+  &:focus {
+    border-color: #cbd3e1;
+    outline: none;
+  }
+`;
 
-// const TextArea = styled.textarea`
-//   padding: 8px;
-//   font-size: 14px;
-//   border: 1px solid #CBD3E1;
-//   border-radius: 12px;
-//   resize: none;
-//   height: 160px;
-//   &:focus {
-//     border-color: #CBD3E1;
-//     outline: none;
-//   }
-// `;
+const SubmitButton = styled.button`
+  padding: 10px 15px;
+  background-color: #cbd3e1;
+  color: #fff;
+  font-size: 16px;
+  border: none;
+  border-radius: 12px;
+  cursor: pointer;
+  font-family: Pretendard;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 32px;
+  text-align: center;
+  text-underline-position: from-font;
+  text-decoration-skip-ink: none;
 
-// const SubmitButton = styled.button`
-//   padding: 10px 15px;
-//   background-color: #CBD3E1;
-//   color: #fff;
-//   font-size: 16px;
-//   border: none;
-//   border-radius: 12px;
-//   cursor: pointer;
-// font-family: Pretendard;
-// font-size: 16px;
-// font-weight: 600;
-// line-height: 32px;
-// text-align: center;
-// text-underline-position: from-font;
-// text-decoration-skip-ink: none;
+  &:hover {
+    background-color: #2d394e;
+  }
+`;
 
-//   &:hover {
-//     background-color: #2d394e;
-//   }
-// `;
+const Message = styled.p`
+  margin-top: 16px;
+  font-size: 14px;
+  color: #2d394e;
+`;
 
-// const Message = styled.p`
-//   margin-top: 16px;
-//   font-size: 14px;
-//   color: #2d394e;
-// `;
+const RadioGroup = styled.div`
+  display: flex;
+  gap: 16px;
+  margin: 4px 0;
+`;
 
+const RadioOption = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 4px;
 
-// const RadioGroup = styled.div`
-//   display: flex;
-//   gap: 16px;
-//   margin: 4px 0;
-// `;
+  input[type='radio'] {
+    width: 20px;
+    height: 20px;
+    accent-color: #40516e;
+    cursor: pointer;
+    transition:
+      background-color 0.3s,
+      border-color 0.3s;
+    &:checked {
+      filter: brightness(1.2);
+    }
+  }
 
-// const RadioOption = styled.div`
-//   display: flex;
-//   align-items: center;
-//   gap: 4px;
-
-//   input[type="radio"] {
-//     width: 20px; 
-//     height: 20px; 
-//     accent-color: #40516E;
-//     cursor: pointer;
-//     transition: background-color 0.3s, border-color 0.3s;
-//     &:checked {
-//         filter: brightness(1.2);
-//     }
-//   }
-
-//   label {
-//     font-family: Pretendard;
-// font-size: 16px;
-// font-weight: 600;
-// line-height: 32px;
-// margin-left: 4px;
-// text-underline-position: from-font;
-// text-decoration-skip-ink: none;
-// cursor: pointer;
-//   }
-// `;
+  label {
+    font-family: Pretendard;
+    font-size: 16px;
+    font-weight: 600;
+    line-height: 32px;
+    margin-left: 4px;
+    text-underline-position: from-font;
+    text-decoration-skip-ink: none;
+    cursor: pointer;
+  }
+`;

--- a/epigram-main/components/EpigramComment.tsx
+++ b/epigram-main/components/EpigramComment.tsx
@@ -1,0 +1,239 @@
+'use client';
+
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import Image from 'next/image';
+import CommentInput from '@/components/CommentInput';
+import { deleteEpigramComment, updateEpigramComment } from '@/lib/apis/comment';
+import { useCommentStore } from '@/store/commentStore';
+import { useAuthStore } from '@/store/authStore';
+interface Writer {
+  id: number;
+  nickname: string;
+  image: string | null;
+}
+
+interface Comment {
+  id: number;
+  content: string;
+  isPrivate: boolean;
+  createdAt: string;
+  updatedAt: string;
+  writer: Writer;
+  epigramId: number;
+}
+
+export default function EpigramComment({
+  comments,
+  epigramId,
+}: {
+  comments: Comment[];
+  epigramId: number;
+}) {
+  const { deleteComment, editCommentId, setEditCommentId, updateComment } = useCommentStore();
+  const { user } = useAuthStore();
+  const [editedContent, setEditedContent] = useState('');
+
+  const handleEditClick = (comment: Comment) => {
+    setEditCommentId(comment.id);
+    setEditedContent(comment.content);
+  };
+
+  const handleUpdate = async (commentId: number) => {
+    try {
+      await updateEpigramComment(commentId, editedContent, true);
+      updateComment(commentId, editedContent);
+      setEditCommentId(null);
+    } catch (error) {
+      console.error('댓글 수정 실패:', error);
+    }
+  };
+
+  const handleDelete = async (commentId: number) => {
+    if (confirm('정말 삭제하시겠습니까?')) {
+      try {
+        await deleteEpigramComment(commentId);
+        deleteComment(commentId);
+      } catch (error) {
+        console.error('댓글 삭제 실패:', error);
+      }
+    }
+  };
+
+  return (
+    <Container>
+      <CommentCountBox>
+        <CountText>댓글 ({comments.length})</CountText>
+      </CommentCountBox>
+      <CommentInput epigramId={epigramId} />
+      <CommentList>
+        {comments.map((comment) => (
+          <CommentItem key={comment.id}>
+            {editCommentId === comment.id ? (
+              <EditContainer>
+                <EditInput
+                  value={editedContent}
+                  onChange={(e) => setEditedContent(e.target.value)}
+                />
+                <ButtonContainer>
+                  <Button className="save" onClick={() => handleUpdate(comment.id)}>
+                    저장
+                  </Button>
+                  <Button onClick={() => setEditCommentId(null)}>취소</Button>
+                </ButtonContainer>
+              </EditContainer>
+            ) : (
+              <CommentContent>
+                <ProfileImgContainer>
+                  {comment.writer.image ? (
+                    <Image src={comment.writer.image} alt="유저" width={24} height={24} />
+                  ) : (
+                    <Image src="/images/user.png" alt="유저" width={24} height={24} />
+                  )}
+                </ProfileImgContainer>
+
+                <CommentHeader>
+                  <CommentInner>
+                    <TextContainer>
+                      <UserText>{comment.writer.nickname}</UserText>
+                      <UserText className="sm">
+                        {new Date(comment.createdAt).toLocaleString()}
+                      </UserText>
+                    </TextContainer>
+                    {comment.writer.id === user?.id && (
+                      <BtnContainer>
+                        <Button onClick={() => handleEditClick(comment)}>수정</Button>
+                        <Button className="del" onClick={() => handleDelete(comment.id)}>
+                          삭제
+                        </Button>
+                      </BtnContainer>
+                    )}
+                  </CommentInner>
+                  <p>{comment.content}</p>
+                </CommentHeader>
+              </CommentContent>
+            )}
+          </CommentItem>
+        ))}
+      </CommentList>
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  margin-top: 20px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+const CommentCountBox = styled.div`
+  width: 100%;
+  width: 640px;
+  margin-bottom: 20px;
+`;
+
+const CountText = styled.h3`
+  font-family: Pretendard;
+  font-size: 20px;
+  font-weight: 600;
+  line-height: 32px;
+  text-align: left;
+  text-underline-position: from-font;
+  text-decoration-skip-ink: none;
+  color: #373737;
+`;
+
+const CommentList = styled.div`
+  margin-top: 10px;
+  width: 640px;
+`;
+
+const CommentItem = styled.div`
+  padding: 20px;
+  border-top: 1px solid #ddd;
+`;
+
+const CommentContent = styled.div`
+  display: flex;
+`;
+
+const ProfileImgContainer = styled.div``;
+
+const CommentHeader = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  margin-left: 20px;
+`;
+
+const CommentInner = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+`;
+
+const TextContainer = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const UserText = styled.p`
+  font-family: Pretendard;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 26px;
+  text-align: left;
+  text-underline-position: from-font;
+  text-decoration-skip-ink: none;
+  color: #5e5e5e;
+  margin-right: 10px;
+  &.sm {
+    font-size: 12px;
+    margin-top: 2px;
+  }
+`;
+
+const BtnContainer = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const Button = styled.button`
+  background: none;
+  border: none;
+  color: #373737;
+  cursor: pointer;
+  font-size: 14px;
+  padding: 0px 8px 4px 8px;
+  margin-left: 2px;
+  text-decoration: underline;
+  &.del {
+    color: #ff6577;
+  }
+  &.save {
+    color: #0070f3;
+  }
+`;
+
+const EditContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const EditInput = styled.textarea`
+  width: 100%;
+  height: 60px;
+  padding: 8px;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+`;
+
+const ButtonContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 5px;
+`;

--- a/epigram-main/components/EpigramDetailInfo.tsx
+++ b/epigram-main/components/EpigramDetailInfo.tsx
@@ -1,8 +1,12 @@
-"use client";
+'use client';
 
-import React from "react";
-import styled from "styled-components";
-import Image from "next/image";
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+import { deleteEpigram } from '@/lib/apis/epigram';
+import { useAuthStore } from '@/store/authStore';
+import { useEpigramStore } from '@/store/epigramStore';
 
 interface EpigramDetail {
   id: number;
@@ -16,72 +20,96 @@ interface EpigramDetail {
   isLiked: boolean;
 }
 
-export default function EpigramDetailInfo({
-  epigram,
-}: {
-  epigram: EpigramDetail;
-}) {
+export default function EpigramDetailInfo({ epigram }: { epigram: EpigramDetail }) {
+  const router = useRouter();
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const { user } = useAuthStore();
+  const { toggleLike } = useEpigramStore();
 
-
-
+  const handleDelete = async () => {
+    if (window.confirm('정말 삭제하시겠습니까?')) {
+      try {
+        await deleteEpigram(epigram.id);
+        alert('삭제되었습니다.');
+        router.push('/epigramlist');
+      } catch (error) {
+        console.error('삭제 실패:', error);
+        alert('삭제에 실패했습니다.');
+      }
+    }
+  };
 
   return (
     <DetailCardContainer>
-    <DetailCardInner>
-    <DetailCard>
-      <TagContainer>
-      <TagText>{epigram.tags.map((tag) => `#${tag.name}`).join(",  ")}</TagText>
-      <Image
-             src="/images/more_vertical.png"
-             alt="메뉴"
-             width={32}
-             height={32}
-             />
-      </TagContainer>
-      <MainText>{epigram.content}</MainText>
-      <AuthorText>- {epigram.author} -</AuthorText>
-      <BtnContainer>
-        <LikeBtn>
-        <Image
-             src="/images/like.png"
-             alt="좋아요"
-             width={30}
-             height={30}
-             style={{ marginRight: "12px" }}
-           />
-           {epigram.likeCount}
-        </LikeBtn>
-        
-        <LinkBtn
-        onClick={() => window.open(epigram.referenceUrl, "_blank", "noopener,noreferrer")}
-        >
-            {epigram.referenceTitle}
-        <Image
-             src="/images/external_link.png"
-             alt="링크"
-             width={30}
-             height={30}
-             style={{ marginLeft: "12px" }}
-           />
-        </LinkBtn>
-      </BtnContainer>
-    </DetailCard>
+      <DetailCardInner>
+        <DetailCard>
+          <TagContainer>
+            <TagText>{epigram.tags.map((tag) => `#${tag.name}`).join(',  ')}</TagText>
+            {epigram.writerId === user?.id && (
+              <MenuContainer>
+                <Image
+                  src="/images/more_vertical.png"
+                  alt="메뉴"
+                  width={32}
+                  height={32}
+                  onClick={() => setIsMenuOpen((prev) => !prev)}
+                  style={{ cursor: 'pointer' }}
+                />
+                {isMenuOpen && (
+                  <DropdownMenu>
+                    <MenuItem onClick={() => router.push(`/editepigram/${epigram.id}`)}>
+                      수정하기
+                    </MenuItem>
+                    <MenuItem onClick={handleDelete}>삭제하기</MenuItem>
+                  </DropdownMenu>
+                )}
+              </MenuContainer>
+            )}
+          </TagContainer>
+          <MainText>{epigram.content}</MainText>
+          <AuthorText>- {epigram.author} -</AuthorText>
+          <BtnContainer>
+            <LikeBtn onClick={toggleLike}>
+              <Image
+                src="/images/like.png"
+                alt="좋아요"
+                width={30}
+                height={30}
+                style={{ marginRight: '12px' }}
+              />
+              {epigram.likeCount}
+            </LikeBtn>
+
+            <LinkBtn
+              onClick={() => window.open(epigram.referenceUrl, '_blank', 'noopener,noreferrer')}
+            >
+              {epigram.referenceTitle}
+              <Image
+                src="/images/external_link.png"
+                alt="링크"
+                width={30}
+                height={30}
+                style={{ marginLeft: '12px' }}
+              />
+            </LinkBtn>
+          </BtnContainer>
+        </DetailCard>
       </DetailCardInner>
-           <Divider>
-           <Image
-             src="/images/landing_line.png"
-             alt="경계선"
-             width={1920}
-             height={10}
-             style={{ objectFit: "cover" }}
-           />
-         </Divider>
-  </DetailCardContainer>
+      <Divider>
+        <Image
+          src="/images/landing_line.png"
+          alt="경계선"
+          width={1920}
+          height={10}
+          style={{ objectFit: 'cover' }}
+        />
+      </Divider>
+    </DetailCardContainer>
   );
 }
 
 const DetailCardContainer = styled.div`
-    width: 100%;
+  width: 100%;
 `;
 
 const DetailCardInner = styled.div`
@@ -93,13 +121,12 @@ const DetailCardInner = styled.div`
   background-size: cover;
   background-position: center;
   width: 100%;
-  height: 440px;
 `;
 
 const DetailCard = styled.div`
-padding: 40px 20px 20px 20px;
-margin-top: 20px;
-max-width: 680px;
+  padding: 40px 20px 20px 20px;
+  margin-top: 40px;
+  width: 680px;
 `;
 
 const Divider = styled.div`
@@ -111,92 +138,122 @@ const Divider = styled.div`
 `;
 
 const TagContainer = styled.div`
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding-top: 20px;
-    padding-bottom: 30px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-top: 20px;
+  padding-bottom: 30px;
 `;
 
 const MainText = styled.h3`
-font-family: IropkeBatangM;
-font-size: 24px;
-font-weight: 400;
-line-height: 40px;
-text-align: left;
-text-underline-position: from-font;
-text-decoration-skip-ink: none;
-color:#373737;
+  font-family: IropkeBatangM;
+  font-size: 24px;
+  font-weight: 400;
+  line-height: 40px;
+  text-align: left;
+  text-underline-position: from-font;
+  text-decoration-skip-ink: none;
+  color: #373737;
 `;
 
 const TagText = styled.p`
-font-family: IropkeBatangM;
-font-size: 20px;
-font-weight: 400;
-line-height: 40px;
-text-align: left;
-text-underline-position: from-font;
-text-decoration-skip-ink: none;
-color:#ABB8CE;
+  font-family: IropkeBatangM;
+  font-size: 20px;
+  font-weight: 400;
+  line-height: 40px;
+  text-align: left;
+  text-underline-position: from-font;
+  text-decoration-skip-ink: none;
+  color: #abb8ce;
 `;
 
 const AuthorText = styled.p`
-font-family: IropkeBatangM;
-font-size: 22px;
-font-weight: 400;
-line-height: 40px;
-text-align: right;
-text-underline-position: from-font;
-text-decoration-skip-ink: none;
-color:#ABB8CE;
-margin-top: 50px;
+  font-family: IropkeBatangM;
+  font-size: 22px;
+  font-weight: 400;
+  line-height: 40px;
+  text-align: right;
+  text-underline-position: from-font;
+  text-decoration-skip-ink: none;
+  color: #abb8ce;
+  margin-top: 50px;
 `;
 
 const BtnContainer = styled.div`
-    display: flex;
-    align-items: center;
-    gap: 20px;
-    justify-content: center;
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  justify-content: center;
 `;
 
 const LikeBtn = styled.button`
-    display: flex;
-    align-items: center;
-    background-color: #373737;
-    border-radius: 100px;
-    padding: 6px 24px;
-font-family: Pretendard;
-font-size: 20px;
-font-weight: 600;
-line-height: 32px;
-text-align: left;
-text-underline-position: from-font;
-text-decoration-skip-ink: none;
-color:#fff;
-cursor: pointer;
-/* &:hover {
+  display: flex;
+  align-items: center;
+  background-color: #373737;
+  border-radius: 100px;
+  padding: 6px 24px;
+  font-family: Pretendard;
+  font-size: 20px;
+  font-weight: 600;
+  line-height: 32px;
+  text-align: left;
+  text-underline-position: from-font;
+  text-decoration-skip-ink: none;
+  color: #fff;
+  cursor: pointer;
+  /* &:hover {
     background-color: #373737;
   } */
 `;
 
 const LinkBtn = styled.button`
-      display: flex;
-    align-items: center;
-    display: flex;
-    align-items: center;
-    border: 1px solid #ABABAB;
-    border-radius: 100px;
-    padding: 6px 24px;
-font-family: Pretendard;
-font-size: 20px;
-font-weight: 600;
-line-height: 32px;
-text-align: left;
-text-underline-position: from-font;
-text-decoration-skip-ink: none;
-color:#ABABAB;
-cursor: pointer;
-/* &:hover {
+  display: flex;
+  align-items: center;
+  display: flex;
+  align-items: center;
+  border: 1px solid #ababab;
+  border-radius: 100px;
+  padding: 6px 24px;
+  font-family: Pretendard;
+  font-size: 20px;
+  font-weight: 600;
+  line-height: 32px;
+  text-align: left;
+  text-underline-position: from-font;
+  text-decoration-skip-ink: none;
+  color: #ababab;
+  cursor: pointer;
+  /* &:hover {
     background-color: #373737;
   } */
+`;
+
+const MenuContainer = styled.div`
+  position: relative;
+`;
+
+const DropdownMenu = styled.div`
+  position: absolute;
+  right: 0;
+  top: 40px;
+  background: white;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  width: 120px;
+`;
+
+const MenuItem = styled.button`
+  padding: 10px 15px;
+  text-align: left;
+  font-size: 14px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  &:hover {
+    background-color: #f0f0f0;
+  }
 `;

--- a/epigram-main/components/EpigramListCard.tsx
+++ b/epigram-main/components/EpigramListCard.tsx
@@ -1,8 +1,8 @@
-"use client";
+'use client';
 
-import React from "react";
-import styled from "styled-components";
-import { useRouter } from "next/navigation";
+import React from 'react';
+import styled from 'styled-components';
+import { useRouter } from 'next/navigation';
 
 interface EpigramCardProps {
   id: number;
@@ -26,18 +26,18 @@ export default function EpigramListCard({
   content,
 }: EpigramCardProps) {
   const router = useRouter();
-
+  console.log('udid', id);
   const handleClick = () => {
     router.push(`/epigrams/${id}`);
   };
 
   return (
     <CardContainer>
-        <TextContainer onClick={handleClick}>
+      <TextContainer onClick={handleClick}>
         <MainText>{content}</MainText>
-        <SubText className="mt">- {author}</SubText> 
-        </TextContainer>
-        <SubText>{tags.map((tag) => `#${tag.name}`).join(", ")}</SubText>
+        <SubText className="mt">- {author}</SubText>
+      </TextContainer>
+      <SubText>{tags.map((tag) => `#${tag.name}`).join(', ')}</SubText>
     </CardContainer>
   );
 }
@@ -48,40 +48,40 @@ const CardContainer = styled.div`
 `;
 
 const TextContainer = styled.div`
-    padding: 16px 16px 10px 16px;
-    border-radius: 12px;
-    background-image: url('/images/card_bg.png');
-    background-size: 110%;
-    background-repeat: no-repeat;
-    background-position: center;
-    word-wrap: break-word;
+  padding: 16px 16px 10px 16px;
+  border-radius: 12px;
+  background-image: url('/images/card_bg.png');
+  background-size: 110%;
+  background-repeat: no-repeat;
+  background-position: center;
+  word-wrap: break-word;
   overflow-wrap: break-word;
   white-space: normal;
-    overflow: hidden;
-    box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.1);
 `;
 
 const MainText = styled.h3`
-font-family: IropkeBatangM;
-font-size: 20px;
-font-weight: 400;
-line-height: 40px;
-text-align: left;
-text-underline-position: from-font;
-text-decoration-skip-ink: none;
-color:#373737;
+  font-family: IropkeBatangM;
+  font-size: 20px;
+  font-weight: 400;
+  line-height: 40px;
+  text-align: left;
+  text-underline-position: from-font;
+  text-decoration-skip-ink: none;
+  color: #373737;
 `;
 
 const SubText = styled.p`
-font-family: IropkeBatangM;
-font-size: 18px;
-font-weight: 400;
-line-height: 40px;
-text-align: right;
-text-underline-position: from-font;
-text-decoration-skip-ink: none;
-color:#ABB8CE;
-&.mt {
-   /* margin-top: 30px; */
+  font-family: IropkeBatangM;
+  font-size: 18px;
+  font-weight: 400;
+  line-height: 40px;
+  text-align: right;
+  text-underline-position: from-font;
+  text-decoration-skip-ink: none;
+  color: #abb8ce;
+  &.mt {
+    /* margin-top: 30px; */
   }
 `;

--- a/epigram-main/components/Header.tsx
+++ b/epigram-main/components/Header.tsx
@@ -1,10 +1,9 @@
-"use client";
+'use client';
 
-import styled from "styled-components";
-import { useAuthStore } from "@/store/authStore";
-import Image from "next/image";
-import { useRouter } from "next/navigation";
-
+import styled from 'styled-components';
+import { useAuthStore } from '@/store/authStore';
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 
 const HeaderContainer = styled.header`
   display: flex;
@@ -21,50 +20,50 @@ const HeaderContainer = styled.header`
 `;
 
 const HeaderLeftContainer = styled.div`
-    display: flex;
-    align-items: center;
-    gap: 20px;
-`
+  display: flex;
+  align-items: center;
+  gap: 20px;
+`;
 
 const LeftTextBtn = styled.p`
-font-family: Pretendard;
-font-size: 16px;
-font-weight: 600;
-line-height: 26px;
-text-align: center;
-text-underline-position: from-font;
-text-decoration-skip-ink: none;
-color:#373737;
-margin-left: 30px;
-padding: 4px 10px 4px 10px;
-cursor: pointer;
+  font-family: Pretendard;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 26px;
+  text-align: center;
+  text-underline-position: from-font;
+  text-decoration-skip-ink: none;
+  color: #373737;
+  margin-left: 30px;
+  padding: 4px 10px 4px 10px;
+  cursor: pointer;
 `;
 
 const HeaderRigthContainer = styled.div`
-    padding: 4px 10px 4px 10px;
-    display: flex;
+  padding: 4px 10px 4px 10px;
+  display: flex;
   justify-content: space-between;
   align-items: center;
   cursor: pointer;
-`
+`;
 
 const UserBtn = styled.p`
-font-family: Pretendard;
-font-size: 14px;
-font-weight: 500;
-line-height: 24px;
-text-align: left;
-text-underline-position: from-font;
-text-decoration-skip-ink: none;
-color:#ABABAB;
-margin-left: 8px;
+  font-family: Pretendard;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 24px;
+  text-align: left;
+  text-underline-position: from-font;
+  text-decoration-skip-ink: none;
+  color: #ababab;
+  margin-left: 8px;
 `;
 
 const Button = styled.button`
   padding: 0.5rem 1rem;
   border: none;
   border-radius: 0.5rem;
-  background-color: #2D394E;
+  background-color: #2d394e;
   color: white;
   cursor: pointer;
   &:hover {
@@ -75,38 +74,37 @@ const Button = styled.button`
 export default function Header() {
   const router = useRouter();
   const { isLoggedIn, user, logout } = useAuthStore();
-  console.log('user',user)
 
   const handleLogout = () => {
     logout();
-    router.push("/");
+    router.push('/');
   };
 
   return (
     <HeaderContainer>
-        <HeaderLeftContainer>
+      <HeaderLeftContainer>
         <Image
           src="/images/logo.png"
           alt="로고"
           width={132}
           height={36}
-          onClick={() => router.push("/")}
-          style={{ cursor: "pointer" }}
+          onClick={() => router.push('/')}
+          style={{ cursor: 'pointer' }}
         />
-       {isLoggedIn && <LeftTextBtn onClick={() => router.push("/epigramlist")}>피드</LeftTextBtn>}
-        </HeaderLeftContainer>
+        {isLoggedIn && <LeftTextBtn onClick={() => router.push('/epigramlist')}>피드</LeftTextBtn>}
+      </HeaderLeftContainer>
       {isLoggedIn ? (
         <HeaderRigthContainer onClick={handleLogout}>
-        <Image
-          src="/images/user.png"
-          alt="유저"
-          width={24}
-          height={24}
-        />
+          {user?.image ? (
+            <Image src={user?.image} alt="유저" width={24} height={24} />
+          ) : (
+            <Image src="/images/user.png" alt="유저" width={24} height={24} />
+          )}
+
           <UserBtn>{user?.nickname}</UserBtn>
         </HeaderRigthContainer>
       ) : (
-         <Button onClick={() => router.push("/login")}>로그인</Button>
+        <Button onClick={() => router.push('/login')}>로그인</Button>
       )}
     </HeaderContainer>
   );

--- a/epigram-main/eslint.config.mjs
+++ b/epigram-main/eslint.config.mjs
@@ -1,6 +1,6 @@
-import { dirname } from "path";
-import { fileURLToPath } from "url";
-import { FlatCompat } from "@eslint/eslintrc";
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { FlatCompat } from '@eslint/eslintrc';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -10,10 +10,10 @@ const compat = new FlatCompat({
 });
 
 const eslintConfig = [
-  ...compat.extends("next/core-web-vitals", "next/typescript"),
+  ...compat.extends('next/core-web-vitals', 'next/typescript'),
   {
     rules: {
-      "@typescript-eslint/no-explicit-any": "off",
+      '@typescript-eslint/no-explicit-any': 'off',
     },
   },
 ];

--- a/epigram-main/lib/apis/comment.ts
+++ b/epigram-main/lib/apis/comment.ts
@@ -1,0 +1,44 @@
+import { axiosInstance } from '@/lib/instance/axios';
+import { CommentRequest, CommentResponse } from '../instance/types';
+
+// 댓글 리스트 가져오기
+export const getEpigramComments = async (epigramId: number, limit: number, cursor?: number) => {
+  const response = await axiosInstance.get(`/epigrams/${epigramId}/comments`, {
+    params: {
+      limit,
+      cursor,
+    },
+  });
+  return response.data;
+};
+
+// 댓글 등록하기
+export const createEpigramComment = async (data: CommentRequest): Promise<CommentResponse> => {
+  const response = await axiosInstance.post<CommentResponse>('/comments', data);
+  console.log('댓글 등록 API 응답:', response.data);
+  return response.data;
+};
+
+// 댓글 삭제 API
+export const deleteEpigramComment = async (commentId: number) => {
+  try {
+    await axiosInstance.delete(`/comments/${commentId}`);
+  } catch (error) {
+    console.error('댓글 삭제 실패:', error);
+    throw error;
+  }
+};
+
+// 댓글 수정 API
+export const updateEpigramComment = async (
+  commentId: number,
+  content: string,
+  isPrivate: boolean,
+) => {
+  try {
+    await axiosInstance.patch(`/comments/${commentId}`, { content, isPrivate });
+  } catch (error) {
+    console.error('댓글 수정 실패:', error);
+    throw error;
+  }
+};

--- a/epigram-main/lib/apis/epigram.ts
+++ b/epigram-main/lib/apis/epigram.ts
@@ -1,43 +1,59 @@
-import { axiosInstance } from "@/lib/instance/axios";
-import { EpigramCreateRequest, EpigramCreateResponse, EpigramDetailResponse, EpigramUpdateRequest, EpigramUpdateResponse} from "../instance/types";
-
+import { axiosInstance } from '@/lib/instance/axios';
+import {
+  EpigramCreateRequest,
+  EpigramCreateResponse,
+  EpigramDetailResponse,
+  EpigramUpdateRequest,
+  EpigramUpdateResponse,
+  EpigramDeleteResponse,
+} from '../instance/types';
 
 // 리스트 받아오기
 export const getEpigramList = async (limit: number, cursor?: number) => {
-    const response = await axiosInstance.get(`/epigrams`, {
-      params: {
-        limit,
-        cursor,
-      },
-    });
-    return response.data;
-  };
-  
-  // 에피그램 생성
-  export const createEpigram = async (
-    data: EpigramCreateRequest
-  ): Promise<EpigramCreateResponse> => {
-    const response = await axiosInstance.post<EpigramCreateResponse>("/epigrams", data);
-    return response.data;
-  };
-  
-  // 상세 조회
-  export const getEpigramDetail = async (
-    id: number
-  ): Promise<EpigramDetailResponse> => {
-    const response = await axiosInstance.get<EpigramDetailResponse>(`/epigrams/${id}`);
-    return response.data;
-  };
-  
+  const response = await axiosInstance.get(`/epigrams`, {
+    params: {
+      limit,
+      cursor,
+    },
+  });
+  return response.data;
+};
 
-  // 에피그램 수정
+// 에피그램 생성
+export const createEpigram = async (data: EpigramCreateRequest): Promise<EpigramCreateResponse> => {
+  const response = await axiosInstance.post<EpigramCreateResponse>('/epigrams', data);
+  return response.data;
+};
+
+// 상세 조회
+export const getEpigramDetail = async (id: number): Promise<EpigramDetailResponse> => {
+  const response = await axiosInstance.get<EpigramDetailResponse>(`/epigrams/${id}`);
+  return response.data;
+};
+
+// 에피그램 수정
 export const updateEpigram = async (
-    id: number,
-    data: EpigramUpdateRequest
-  ): Promise<EpigramUpdateResponse> => {
-    const response = await axiosInstance.patch<EpigramUpdateResponse>(
-      `/epigrams/${id}`,
-      data
-    );
-    return response.data;
-  };
+  id: number,
+  data: EpigramUpdateRequest,
+): Promise<EpigramUpdateResponse> => {
+  const response = await axiosInstance.patch<EpigramUpdateResponse>(`/epigrams/${id}`, data);
+  return response.data;
+};
+
+// 에피그램 삭제
+export const deleteEpigram = async (id: number): Promise<EpigramDeleteResponse> => {
+  const response = await axiosInstance.delete<EpigramDeleteResponse>(`/epigrams/${id}`);
+  return response.data;
+};
+
+// 좋아요 추가
+export const likeEpigram = async (id: number) => {
+  const response = await axiosInstance.post(`/epigrams/${id}/like`);
+  return response.data;
+};
+
+// 좋아요 취소
+export const unlikeEpigram = async (id: number) => {
+  const response = await axiosInstance.delete(`/epigrams/${id}/like`);
+  return response.data;
+};

--- a/epigram-main/lib/instance/types.ts
+++ b/epigram-main/lib/instance/types.ts
@@ -20,7 +20,6 @@ export interface LoginRequest {
   password: string;
 }
 
-
 // 회원가입 관련 타입
 export interface SignUpRequest {
   email: string;
@@ -112,4 +111,28 @@ export interface EpigramUpdateResponse {
   author: string;
   content: string;
   id: number;
+}
+
+export interface EpigramDeleteResponse {
+  id: number;
+}
+
+export interface CommentRequest {
+  epigramId: number;
+  isPrivate: boolean;
+  content: string;
+}
+
+export interface CommentResponse {
+  id: number;
+  content: string;
+  isPrivate: boolean;
+  createdAt: string;
+  updatedAt: string;
+  writer: {
+    id: number;
+    nickname: string;
+    image: string | null;
+  };
+  epigramId: number;
 }

--- a/epigram-main/next.config.ts
+++ b/epigram-main/next.config.ts
@@ -1,9 +1,12 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   compiler: {
     styledComponents: true,
+  },
+  images: {
+    domains: ['image-notepet.akamaized.net'],
   },
 };
 

--- a/epigram-main/package-lock.json
+++ b/epigram-main/package-lock.json
@@ -24,6 +24,7 @@
         "eslint": "^9",
         "eslint-config-next": "15.1.5",
         "postcss": "8.5.1",
+        "prettier": "3.4.2",
         "tailwindcss": "3.4.17",
         "typescript": "^5"
       }
@@ -4719,6 +4720,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
+      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prop-types": {

--- a/epigram-main/package.json
+++ b/epigram-main/package.json
@@ -25,6 +25,7 @@
     "eslint": "^9",
     "eslint-config-next": "15.1.5",
     "postcss": "8.5.1",
+    "prettier": "3.4.2",
     "tailwindcss": "3.4.17",
     "typescript": "^5"
   }

--- a/epigram-main/store/authStore.ts
+++ b/epigram-main/store/authStore.ts
@@ -1,5 +1,5 @@
-import { create } from "zustand";
-import { persist } from "zustand/middleware";
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
 interface User {
   id: number;
@@ -47,13 +47,13 @@ export const useAuthStore = create<AuthState>()(
         }),
     }),
     {
-      name: "auth-storage", // 로컬 스토리지 키 이름
+      name: 'auth-storage',
       partialize: (state) => ({
         isLoggedIn: state.isLoggedIn,
         accessToken: state.accessToken,
         refreshToken: state.refreshToken,
         user: state.user,
       }),
-    }
-  )
+    },
+  ),
 );

--- a/epigram-main/store/commentStore.ts
+++ b/epigram-main/store/commentStore.ts
@@ -1,0 +1,60 @@
+import { create } from 'zustand';
+import { getEpigramComments } from '@/lib/apis/comment';
+
+interface Writer {
+  id: number;
+  nickname: string;
+  image: string | null;
+}
+
+interface Comment {
+  id: number;
+  content: string;
+  isPrivate: boolean;
+  createdAt: string;
+  updatedAt: string;
+  writer: Writer;
+  epigramId: number;
+}
+
+interface CommentStore {
+  comments: Comment[];
+  fetchComments: (epigramId: number, limit: number) => Promise<void>;
+  addComment: (newComment: Comment) => void;
+  deleteComment: (commentId: number) => void;
+  editCommentId: number | null;
+  setEditCommentId: (commentId: number | null) => void;
+  updateComment: (commentId: number, content: string) => void;
+}
+
+export const useCommentStore = create<CommentStore>((set) => ({
+  comments: [],
+  editCommentId: null,
+  fetchComments: async (epigramId, limit) => {
+    try {
+      const response = await getEpigramComments(epigramId, limit);
+      set({ comments: response.list });
+    } catch (error) {
+      console.error('댓글 불러오기 실패:', error);
+    }
+  },
+  addComment: (newComment) => {
+    set((state) => ({
+      comments: [newComment, ...state.comments],
+    }));
+  },
+  deleteComment: (commentId) => {
+    set((state) => ({
+      comments: state.comments.filter((comment) => comment.id !== commentId),
+    }));
+  },
+  setEditCommentId: (commentId) => set({ editCommentId: commentId }),
+
+  updateComment: (commentId, content) => {
+    set((state) => ({
+      comments: state.comments.map((comment) =>
+        comment.id === commentId ? { ...comment, content } : comment,
+      ),
+    }));
+  },
+}));

--- a/epigram-main/store/epigramStore.ts
+++ b/epigram-main/store/epigramStore.ts
@@ -1,4 +1,5 @@
-import { create } from "zustand";
+import { create } from 'zustand';
+import { likeEpigram, unlikeEpigram } from '@/lib/apis/epigram';
 
 interface Epigram {
   likeCount: number;
@@ -11,80 +12,54 @@ interface Epigram {
   id: number;
 }
 
-interface EpigramStore {
-  epigrams: Epigram[];
-  setEpigrams: (epigrams: Epigram[]) => void;
+interface EpigramDetail extends Epigram {
+  isLiked: boolean;
 }
 
-const dummyEpigrams: Epigram[] = [
-    {
-      id: 1,
-      likeCount: 12,
-      tags: [{ name: "인생", id: 201 }, { name: "성장", id: 202 }],
-      writerId: 301,
-      referenceUrl: "https://naver.com1",
-      referenceTitle: "삶의 지혜",
-      author: "작가 1",
-      content: "삶은 매일 새로운 기회를 제공하지만, 이를 알아보는 것은 우리의 몫이다. 주어진 시간에 최선을 다하라.",
-    },
-    {
-      id: 2,
-      likeCount: 8,
-      tags: [{ name: "지혜", id: 203 }, { name: "철학", id: 204 }],
-      writerId: 302,
-      referenceUrl: "https://naver.com2",
-      referenceTitle: "지혜로운 삶",
-      author: "작가 2",
-      content: "지혜는 경험에서 나오는 것이 아니라, 경험을 어떻게 활용하느냐에 따라 결정된다.",
-    },
-    {
-      id: 3,
-      likeCount: 20,
-      tags: [{ name: "도전", id: 205 }, { name: "희망", id: 206 }],
-      writerId: 303,
-      referenceUrl: "https://naver.com3",
-      referenceTitle: "희망의 등불",
-      author: "작가 3",
-      content: "어두운 밤이 길수록 새벽은 더욱 찬란하다. 어려움 속에서도 희망을 잃지 마라.",
-    },
-    {
-      id: 4,
-      likeCount: 15,
-      tags: [{ name: "사랑", id: 207 }, { name: "공감", id: 208 }],
-      writerId: 304,
-      referenceUrl: "https://naver.com4",
-      referenceTitle: "사랑의 정의",
-      author: "작가 4",
-      content: "사랑은 서로 다른 두 마음이 하나로 연결되는 순간에 서로가 사랑하게 된다.",
-    },
-    {
-      id: 5,
-      likeCount: 25,
-      tags: [{ name: "책", id: 209 }, { name: "독서", id: 210 }],
-      writerId: 305,
-      referenceUrl: "https://naver.com5",
-      referenceTitle: "독서의 즐거움",
-      author: "작가 5",
-      content: "책을 읽는다는 것은 새로운 세상으로 떠나는 여행과 같다. 독서는 우리의 영혼을 풍요롭게 한다.",
-    },
-    {
-      id: 6,
-      likeCount: 18,
-      tags: [
-        { name: "자기계발", id: 211 },
-        { name: "목표", id: 212 },
-        { name: "성취", id: 213 },
-      ],
-      writerId: 306,
-      referenceUrl: "https://naver.com6",
-      referenceTitle: "목표를 이루는 법",
-      author: "작가 6",
-      content: "작은 목표를 이루는 것이 큰 목표를 달성하는 첫걸음이다. 꾸준히 걸어가는 것이 중요하다.",
-    },
-  ];
-  
+interface EpigramStore {
+  epigrams: Epigram[];
+  epigramDetail: EpigramDetail | null;
+  setEpigrams: (epigrams: Epigram[]) => void;
+  addEpigrams: (newEpigrams: Epigram[]) => void;
+  setEpigramDetail: (epigram: EpigramDetail | null) => void;
+  toggleLike: () => Promise<void>;
+}
 
-export const useEpigramStore = create<EpigramStore>((set) => ({
-  epigrams: dummyEpigrams, // 기본값으로 더미 데이터 설정
+export const useEpigramStore = create<EpigramStore>((set, get) => ({
+  epigrams: [],
+  epigramDetail: null,
   setEpigrams: (epigrams) => set({ epigrams }),
+  addEpigrams: (newEpigrams) => set((state) => ({ epigrams: [...state.epigrams, ...newEpigrams] })),
+  setEpigramDetail: (epigram) => set({ epigramDetail: epigram }),
+
+  toggleLike: async () => {
+    const epigram = get().epigramDetail;
+    if (!epigram) return;
+
+    try {
+      let updatedLikeCount = epigram.likeCount;
+      let updatedIsLiked = epigram.isLiked;
+
+      if (epigram.isLiked) {
+        await unlikeEpigram(epigram.id);
+        updatedLikeCount -= 1;
+        updatedIsLiked = false;
+      } else {
+        await likeEpigram(epigram.id);
+        updatedLikeCount += 1;
+        updatedIsLiked = true;
+      }
+
+      set({
+        epigramDetail: {
+          ...epigram,
+          likeCount: updatedLikeCount,
+          isLiked: updatedIsLiked,
+        },
+      });
+    } catch (error) {
+      console.error('좋아요 처리 실패:', error);
+      alert('좋아요 기능을 사용할 수 없습니다.');
+    }
+  },
 }));


### PR DESCRIPTION
- 프리티어 설정
- 헤더 프로필 이미지 분기 처리
- 토큰 로직 수정
- 더미 데이터 제거 
- 에피그램 list조회 api 연동 & 타입 수정 & 데이터 바인딩
- 더보기 기능 구현 (6페이지씩)
- 에피그램 상세 조회 api 연동 & 타입 수정 & 데이터 바인딩
- 에피그램 삭제 기능 구현
- 에피그램 좋아요 & 좋아요 취소 api 연동 및 기능 구현
- 에피그램 수정 하기 기능 구현 (주석 제거 및 기존 api test)
- 에피그램 작성하기 api 연동 및 기능 구현 일부 수정
- 글자 수 150글자 제한 (원래 500글자), 본인 데이터 나오게 수정
- 태그 요구 사항 적용 (최대 3개, 한 태그 당 최대 10자 제한)
- 로그인 & 회원가입 유효성 추가 (회원가입 중복 닉네임 에러코드 없어서 넘어감)
- 에피 그램 상세 페이지 퍼블리싱 (댓글)
- 댓글 수정 및 삭제 api 연동 및 기능 구현
- 댓글 등록 api 연동 및 기능 구현
- 댓글 수정 ui 임의로 추가
